### PR TITLE
[squid:S00122] Statements should be on separate lines

### DIFF
--- a/src/main/java/eu/strutters/example/todo/action/TodoListAction.java
+++ b/src/main/java/eu/strutters/example/todo/action/TodoListAction.java
@@ -31,8 +31,10 @@ public class TodoListAction implements Action {
 	public String execute() throws Exception {
 
 		Criteria criteria = todoItemService.createCriteria();
-		if(category != null) criteria.add(Restrictions.eq("category", category)) ;
-		if(dueDate != null) criteria.add(Restrictions.eq("dueDate", dueDate)) ;
+		if(category != null) 
+			criteria.add(Restrictions.eq("category", category)) ;
+		if(dueDate != null) 
+			criteria.add(Restrictions.eq("dueDate", dueDate)) ;
 
 		items = todoItemService.list(criteria);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S00122 - “Statements should be on separate lines”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S00122

Please let me know if you have any questions.
Ayman Abdelghany.
