### PR TITLE
[squid:S2293] The operator ("<>") should be used.

### DIFF
--- a/src/main/java/eu/strutters/example/todo/service/GenericEntityService.java
+++ b/src/main/java/eu/strutters/example/todo/service/GenericEntityService.java
@@ -57,7 +57,7 @@ public abstract class GenericEntityService<T, I extends Serializable> {
 	}
 
 	public <M extends T> List<M> bulkSaveOrUpdate(M... modelObject) {
-		final List<M> result = new ArrayList<M>();
+		final List<M> result = new ArrayList<>();
 		for (M m : modelObject) {
 			getCurrentSession().saveOrUpdate(m);
 			result.add(m);
@@ -122,7 +122,7 @@ public abstract class GenericEntityService<T, I extends Serializable> {
 		if (toSave == null || toSave.isEmpty()) {
 			return Collections.emptyList();
 		}
-		List<M> result = new ArrayList<M>(toSave.size());
+		List<M> result = new ArrayList<>(toSave.size());
 		for (M m : toSave) {
 			result.add(saveOrUpdate(m));
 		}
@@ -137,7 +137,7 @@ public abstract class GenericEntityService<T, I extends Serializable> {
 		if (toSave == null || toSave.isEmpty()) {
 			return Collections.emptyList();
 		}
-		List<M> result = new ArrayList<M>(toSave.size());
+		List<M> result = new ArrayList<>(toSave.size());
 		for (M m : toSave) {
 			result.add((M) merge(m));
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - “The diamond operator ("<>") should be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293

Please let me know if you have any questions.
Ayman Abdelghany.
