### PR TITLE
[squid:ModifiersOrderCheck] Modifiers should be declared in the corre

### DIFF
--- a/src/main/java/eu/strutters/example/todo/service/GenericEntityService.java
+++ b/src/main/java/eu/strutters/example/todo/service/GenericEntityService.java
@@ -108,9 +108,8 @@ public abstract class GenericEntityService<T, I extends Serializable> {
 	}
 
 
-	public
 	@Nullable
-	<M> M first(List<M> list) {
+	public <M> M first(List<M> list) {
 		if (list != null && list.size() > 0) {
 			return list.get(0);
 		} else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ModifiersOrderCheck - “Modifiers should be declared in the correct order”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.
Ayman Abdelghany.
